### PR TITLE
IPv6 CLI parser and support for wide fields in network byte order

### DIFF
--- a/include/nikss.h
+++ b/include/nikss.h
@@ -101,6 +101,7 @@ typedef struct nikss_struct_field_descriptor {
 typedef struct nikss_struct_field_descriptor_set {
     size_t n_fields;
     nikss_struct_field_descriptor_t *fields;
+    bool decoded_with_btf;
 } nikss_struct_field_descriptor_set_t;
 
 /* Used to read/write structures */

--- a/lib/common.c
+++ b/lib/common.c
@@ -141,7 +141,7 @@ static size_t count_total_fields(nikss_btf_t *btf_md, uint32_t type_id)
 {
     const struct btf_type *type = btf_get_type_by_id(btf_md->btf, type_id);
 
-    if (btf_is_int(type)) {
+    if (btf_is_int(type) || btf_is_array(type)) {
         return 1;
     }
 
@@ -197,7 +197,7 @@ static int setup_struct_field_descriptor_set_btf(nikss_btf_t *btf_md, nikss_stru
         return EINVAL;
     }
 
-    if (btf_is_int(type)) {
+    if (btf_is_int(type) || btf_is_array(type)) {
         if (*field_idx >= fds->n_fields) {
             goto too_many_fields;
         }

--- a/lib/common.c
+++ b/lib/common.c
@@ -297,6 +297,7 @@ int parse_struct_type(nikss_btf_t *btf_md, uint32_t type_id, size_t data_size, n
 {
     if (type_id == 0) {
         fprintf(stderr, "warning: BTF type not found, placing all the data in a single field\n");
+        fds->decoded_with_btf = false;
         return setup_struct_field_descriptor_set_no_btf(fds, data_size);
     }
 
@@ -309,6 +310,7 @@ int parse_struct_type(nikss_btf_t *btf_md, uint32_t type_id, size_t data_size, n
         return EINVAL;
     }
 
+    fds->decoded_with_btf = true;
     unsigned field_idx = 0;
     return setup_struct_field_descriptor_set_btf(btf_md, fds, type_id, &field_idx, 0);
 }
@@ -423,6 +425,7 @@ int construct_struct_from_fields(nikss_struct_field_set_t *data, nikss_struct_fi
             ++field_idx;
         }
         if (!failed) {
+            fix_struct_data_byte_order(fds, buffer, buffer_len);
             return NO_ERROR;
         }
     }
@@ -446,4 +449,24 @@ int construct_struct_from_fields(nikss_struct_field_set_t *data, nikss_struct_fi
 
     fprintf(stderr, "failed to construct data type\n");
     return EINVAL;
+}
+
+void fix_struct_data_byte_order(nikss_struct_field_descriptor_set_t *fds, char *buffer, size_t buffer_len) {
+    if (!fds->decoded_with_btf) {
+        return;
+    }
+
+    for (unsigned descriptor_idx = 0; descriptor_idx < fds->n_fields; descriptor_idx++) {
+        if (fds->fields[descriptor_idx].type != NIKSS_STRUCT_FIELD_TYPE_DATA) {
+            continue;
+        }
+        if (fds->fields[descriptor_idx].data_len + fds->fields[descriptor_idx].data_offset > buffer_len) {
+            /* silently ignore error, probably should be caught somewhere else */
+            break;
+        }
+        if (fds->fields[descriptor_idx].data_len > 8) {
+            swap_byte_order(buffer + fds->fields[descriptor_idx].data_offset,
+                            fds->fields[descriptor_idx].data_len);
+        }
+    }
 }

--- a/lib/common.h
+++ b/lib/common.h
@@ -43,4 +43,7 @@ int struct_field_set_append(nikss_struct_field_set_t *sfs, const void *data, siz
 int construct_struct_from_fields(nikss_struct_field_set_t *data, nikss_struct_field_descriptor_set_t *fds,
                                  char *buffer, size_t buffer_len);
 
+/* Will swap byte order of fields if required in buffer */
+void fix_struct_data_byte_order(nikss_struct_field_descriptor_set_t *fds, char *buffer, size_t buffer_len);
+
 #endif  /* __NIKSS_COMMON_H */

--- a/lib/nikss_counter.c
+++ b/lib/nikss_counter.c
@@ -360,6 +360,8 @@ nikss_counter_entry_t *nikss_counter_get_next(nikss_counter_context_t *ctx)
         return NULL;
     }
 
+    fix_struct_data_byte_order(&ctx->key_fds, ctx->current_entry.raw_key, ctx->counter.key_size);
+
     return &ctx->current_entry;
 }
 

--- a/lib/nikss_digest.c
+++ b/lib/nikss_digest.c
@@ -112,6 +112,8 @@ int nikss_digest_get_next(nikss_digest_context_t *ctx, nikss_digest_t *digest)
         return ret;
     }
 
+    fix_struct_data_byte_order(&ctx->fds, digest->raw_data, ctx->queue.value_size);
+
     return NO_ERROR;
 }
 

--- a/lib/nikss_meter.c
+++ b/lib/nikss_meter.c
@@ -364,6 +364,8 @@ nikss_meter_entry_t *nikss_meter_get_next(nikss_meter_ctx_t *ctx)
         goto clean_up;
     }
 
+    fix_struct_data_byte_order(&ctx->index_fds, ctx->current_entry.raw_index, ctx->meter.key_size);
+
     nikss_meter_data_t data;
     memcpy(&data, value_buffer, sizeof(data));
     return_code = convert_meter_data_to_entry(&data, &ctx->current_entry);

--- a/lib/nikss_register.c
+++ b/lib/nikss_register.c
@@ -261,6 +261,9 @@ nikss_register_entry_t * nikss_register_get_next(nikss_register_context_t *ctx)
         return NULL;
     }
 
+    fix_struct_data_byte_order(&ctx->key_fds, ctx->current_entry.raw_key, ctx->reg.key_size);
+    fix_struct_data_byte_order(&ctx->value_fds, ctx->current_entry.raw_value, ctx->reg.value_size);
+
     return &ctx->current_entry;
 }
 
@@ -285,6 +288,8 @@ int nikss_register_get(nikss_register_context_t *ctx, nikss_register_entry_t *en
         fprintf(stderr, "failed to read Register entry: %s\n", strerror(ret));
         return ret;
     }
+
+    fix_struct_data_byte_order(&ctx->value_fds, ctx->current_entry.raw_value, ctx->reg.value_size);
 
     return NO_ERROR;
 }


### PR DESCRIPTION
closes #77 
PTF tests: https://github.com/tatry/p4c/pull/27 (only tables, support for externes no included)

TODO for fieldst >64 bits:
- [x] Reverse order of bytes when read table.
- [x] Reverse byte order when writing/reading externs.