### PR TITLE
Invalid byte order on single entry get in Counter, Meter and Register

### DIFF
--- a/lib/nikss_counter.c
+++ b/lib/nikss_counter.c
@@ -305,6 +305,9 @@ static int read_and_parse_counter_value(nikss_counter_context_t *ctx, nikss_coun
         return ret;
     }
 
+    /* raw_key is always used as a data source for user request on next field, so convert it to right byte order */
+    fix_struct_data_byte_order(&ctx->key_fds, entry->raw_key, ctx->counter.key_size);
+
     return convert_counter_data_to_entry(value, ctx->counter.value_size, ctx->counter_type, entry);
 }
 
@@ -359,8 +362,6 @@ nikss_counter_entry_t *nikss_counter_get_next(nikss_counter_context_t *ctx)
     if (read_and_parse_counter_value(ctx, &ctx->current_entry) != NO_ERROR) {
         return NULL;
     }
-
-    fix_struct_data_byte_order(&ctx->key_fds, ctx->current_entry.raw_key, ctx->counter.key_size);
 
     return &ctx->current_entry;
 }

--- a/lib/nikss_meter.c
+++ b/lib/nikss_meter.c
@@ -306,6 +306,9 @@ int nikss_meter_entry_get(nikss_meter_ctx_t *ctx, nikss_meter_entry_t *entry)
         goto clean_up;
     }
 
+    /* Later raw_index is used instead of user provided data, so fix its byte order */
+    fix_struct_data_byte_order(&ctx->index_fds, entry->raw_index, ctx->meter.key_size);
+
     nikss_meter_data_t data;
     memcpy(&data, value_buffer, sizeof(data));
     return_code = convert_meter_data_to_entry(&data, entry);

--- a/lib/nikss_register.c
+++ b/lib/nikss_register.c
@@ -289,7 +289,8 @@ int nikss_register_get(nikss_register_context_t *ctx, nikss_register_entry_t *en
         return ret;
     }
 
-    fix_struct_data_byte_order(&ctx->value_fds, ctx->current_entry.raw_value, ctx->reg.value_size);
+    fix_struct_data_byte_order(&ctx->value_fds, entry->raw_key, ctx->reg.key_size);
+    fix_struct_data_byte_order(&ctx->value_fds, entry->raw_value, ctx->reg.value_size);
 
     return NO_ERROR;
 }


### PR DESCRIPTION
Externs: Counter (rather to impossible to exploit), Meter and Register might return invalid byte order of fields wider than 8 bytes if single entry was requested using index/key. These externs returns field data using internal raw buffer (not data provided by user) where byte order was not correct.

PTF tests: https://github.com/tatry/p4c/pull/30