### PR TITLE
Refactor CMakeLists.txt. Add custom target for headers installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,11 +63,11 @@ include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_S
 if (BUILD_SHARED)
   # shared library
   add_library(nikss SHARED ${NIKSSLIB_SRCS})
-  target_link_libraries(nikss ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/lib64/libbpf.a z elf)
+  target_link_libraries(nikss ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/lib64/libbpf.a z m elf)
 
   # When cmd tool is built with shared library then it do not contains library code
   add_executable(nikss-ctl ${NIKSSCTL_SRCS})
-  target_link_libraries(nikss-ctl nikss z elf gmp m jansson)
+  target_link_libraries(nikss-ctl nikss gmp jansson)
 else ()
   # build one binary with all the code built-in
   add_executable(nikss-ctl ${NIKSSLIB_SRCS} ${NIKSSCTL_SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(nikss C)
 
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
 set(CMAKE_C_STANDARD 11)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
@@ -59,6 +61,13 @@ add_definitions(-D_GNU_SOURCE)
 
 # Add include directories on top of the list
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/include)
+
+# validate if dependencies are met
+find_package(LibGmp REQUIRED)
+find_package(LibElf REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(Jansson REQUIRED)
+find_package(LibBpf REQUIRED)
 
 if (BUILD_SHARED)
   # shared library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,23 +57,35 @@ set(NIKSSCTL_SRCS
 add_definitions(-D_XOPEN_SOURCE=500)
 add_definitions(-D_GNU_SOURCE)
 
+# Add include directories on top of the list
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/include)
+
 if (BUILD_SHARED)
+  # shared library
   add_library(nikss SHARED ${NIKSSLIB_SRCS})
   target_link_libraries(nikss ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/lib64/libbpf.a z elf)
-  install(TARGETS nikss DESTINATION lib)
+
+  # When cmd tool is built with shared library then it do not contains library code
   add_executable(nikss-ctl ${NIKSSCTL_SRCS})
-else ()
-  add_executable(nikss-ctl ${NIKSSLIB_SRCS} ${NIKSSCTL_SRCS})
-endif ()
-include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/include)
-if (BUILD_SHARED)
-  link_directories(${CMAKE_CURRENT_BINARY_DIR})
   target_link_libraries(nikss-ctl nikss z elf gmp m jansson)
 else ()
-  target_link_libraries(nikss-ctl z elf gmp m jansson)
+  # build one binary with all the code built-in
+  add_executable(nikss-ctl ${NIKSSLIB_SRCS} ${NIKSSCTL_SRCS})
+  target_link_libraries(nikss-ctl ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/lib64/libbpf.a z elf gmp m jansson)
 endif ()
-target_link_libraries(nikss-ctl ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/lib64/libbpf.a z elf)
+
+# installation rules
+if (BUILD_SHARED)
+  install(TARGETS nikss DESTINATION lib)
+endif ()
 install(TARGETS nikss-ctl RUNTIME DESTINATION bin)
+
+# headers installation
+set(HEADERS_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include/nikss)
+add_custom_target(install_headers
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${HEADERS_INSTALL_PATH}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h ${HEADERS_INSTALL_PATH}
+        COMMENT "Install C/C++ headers into ${HEADERS_INSTALL_PATH}")
 
 # linter
 set(C_LANG_OPTIONS_CHECK

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ system-wide. It is a submodule for this repository.
    ./build_libbpf.sh
    ```
 
-3. Build the code and install files:
+3. Build the code and install binaries:
 
    ```shell
    mkdir build
@@ -107,6 +107,14 @@ system-wide. It is a submodule for this repository.
      echo "/usr/local/lib" > /etc/ld.so.conf.d/usr_local_lib.conf
      ldconfig
      ```
+
+4. (Optional) Install C/C++ headers files:
+
+   ```shell
+   sudo make install_headers
+   ```
+   This step makes sense only when shared library is built (`BUILD_SHARED` is set to `on`) because otherwise linker will
+   fail to find references to the `libnikss` library.
 
 # Commands reference
 

--- a/cmake/FindJansson.cmake
+++ b/cmake/FindJansson.cmake
@@ -1,0 +1,31 @@
+# Copyright 2023 Orange
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Try to find Jansson library
+#
+# The following variables are set:
+# JANSSON_FOUND - System has Jansson
+# JANSSON_LIBRARIES - The libraries needed to use Jansson
+# JANSSON_INCLUDE_DIR - The Jansson include directory
+
+find_path(JANSSON_INCLUDE_DIR jansson.h)
+
+find_library(JANSSON_LIBRARIES NAMES jansson)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Jansson DEFAULT_MSG
+        JANSSON_LIBRARIES
+        JANSSON_INCLUDE_DIR)
+
+mark_as_advanced(JANSSON_INCLUDE_DIR JANSSON_LIBRARIES)

--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -1,0 +1,37 @@
+# Copyright 2023 Orange
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Try to find libbpf library
+#
+# The following variables are set:
+# LIBBPF_FOUND - libbpf has been found
+# LIBBPF_LIBRARIES - The libraries needed to use libbpf
+# LIBBPF_INCLUDE_DIR - The libbpf include directory
+
+find_path(LIBBPF_INCLUDE_DIR NAMES bpf/libbpf.h
+        PATHS
+        ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/include
+        NO_DEFAULT_PATH)
+
+find_library(LIBBPF_LIBRARIES NAMES libbpf.a
+        PATHS
+        ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/lib64
+        NO_DEFAULT_PATH)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibBpf "Could NOT find libbpf; did you run the build_libbpf.sh script?"
+        LIBBPF_LIBRARIES
+        LIBBPF_INCLUDE_DIR)
+
+mark_as_advanced(LIBBPF_INCLUDE_DIR LIBBPF_LIBRARIES)

--- a/cmake/FindLibElf.cmake
+++ b/cmake/FindLibElf.cmake
@@ -1,0 +1,64 @@
+# - Try to find libelf
+# Once done this will define
+#
+#  LIBELF_FOUND - system has libelf
+#  LIBELF_INCLUDE_DIRS - the libelf include directory
+#  LIBELF_LIBRARIES - Link these to use libelf
+#  LIBELF_DEFINITIONS - Compiler switches required for using libelf
+#
+#  Copyright (c) 2008 Bernhard Walle <bernhard.walle@gmx.de>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+
+if (LIBELF_LIBRARIES AND LIBELF_INCLUDE_DIRS)
+    set (LibElf_FIND_QUIETLY TRUE)
+endif (LIBELF_LIBRARIES AND LIBELF_INCLUDE_DIRS)
+
+find_path (LIBELF_INCLUDE_DIRS
+        NAMES
+        libelf.h
+        PATHS
+        /usr/include
+        /usr/include/libelf
+        /usr/local/include
+        /usr/local/include/libelf
+        /opt/local/include
+        /opt/local/include/libelf
+        /sw/include
+        /sw/include/libelf
+        ENV CPATH)
+
+find_library (LIBELF_LIBRARIES
+        NAMES
+        elf
+        PATHS
+        /usr/lib
+        /usr/local/lib
+        /opt/local/lib
+        /sw/lib
+        ENV LIBRARY_PATH
+        ENV LD_LIBRARY_PATH)
+
+include (FindPackageHandleStandardArgs)
+
+
+# handle the QUIETLY and REQUIRED arguments and set LIBELF_FOUND to TRUE if all listed variables are TRUE
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibElf DEFAULT_MSG
+        LIBELF_LIBRARIES
+        LIBELF_INCLUDE_DIRS)
+
+SET(CMAKE_REQUIRED_LIBRARIES elf)
+INCLUDE(CheckCSourceCompiles)
+CHECK_C_SOURCE_COMPILES("#include <libelf.h>
+int main() {
+  Elf *e = (Elf*)0;
+  size_t sz;
+  elf_getshdrstrndx(e, &sz);
+  return 0;
+}" ELF_GETSHDRSTRNDX)
+
+mark_as_advanced(LIBELF_INCLUDE_DIRS LIBELF_LIBRARIES ELF_GETSHDRSTRNDX)

--- a/cmake/FindLibGmp.cmake
+++ b/cmake/FindLibGmp.cmake
@@ -1,0 +1,50 @@
+# Copyright 2017 Xilinx, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# FindLibGmp
+# -----------
+#
+# Try to find LibGmp the GNU Multiple Precision Arithmetic Library (only for C language)
+#
+# Once done this will define
+#
+# ::
+#
+#   LIBGMP_FOUND - System has LibGmp
+#   LIBGMP_INCLUDE_DIR - The LibGmp include directory
+#   LIBGMP_LIBRARIES - The libraries needed to use LibGmp
+#   LIBGMP_DEFINITIONS - Compiler switches required for using LibGmp
+find_package(PkgConfig QUIET)
+find_package(Threads)
+PKG_CHECK_MODULES(PC_LIBGMP QUIET gmp)
+set(LIBGMP_DEFINITIONS ${PC_LIBGMP_CFLAGS_OTHER})
+
+
+find_path(LIBGMP_INCLUDE_DIR NAMES gmp.h
+        HINTS
+        ${PC_LIBGMP_INCLUDEDIR}
+        ${PC_LIBGMP_INCLUDE_DIRS}
+        )
+
+find_library(LIBGMP_LIBRARIES NAMES gmp libgmp
+        HINTS
+        ${PC_LIBGMP_LIBDIR}
+        ${PC_LIBGMP_LIBRARY_DIRS}
+        )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibGmp
+        REQUIRED_VARS LIBGMP_LIBRARIES LIBGMP_INCLUDE_DIR
+        )
+mark_as_advanced(LIBGMP_INCLUDE_DIR LIBGMP_LIBRARIES)


### PR DESCRIPTION
- Improved readability of the build process.
- Removed unnecessary libraries to link.
- Added target to install headers.
- Added checks to validate installation of dependencies.