### PR TITLE
Fix definition of nikss_match_key for range key

### DIFF
--- a/include/nikss/nikss.h
+++ b/include/nikss/nikss.h
@@ -302,8 +302,8 @@ typedef struct nikss_match_key {
         } lpm;
         struct {
             // used only for 'range'
-            const uint64_t start;
-            const uint64_t end;
+            uint64_t start;
+            uint64_t end;
         } range;
     } u;
 


### PR DESCRIPTION
Definition of struct contained `const` entries which forbids compilation using (modern) C++ compiler when using `nikss_match_key`. There is no problems with C compiler.

Solution is just to remove `const` qualifier.